### PR TITLE
Fix login validation return logic

### DIFF
--- a/src/features/auth/domain/rules.ts
+++ b/src/features/auth/domain/rules.ts
@@ -252,6 +252,10 @@ export const validateLoginForm = (form: LoginForm): ValidationResult => {
       errors.push(new Error('Password is required'));
     }
 
+    if (errors.length > 0) {
+      return { isValid: false, errors };
+    }
+
     return { isValid: true };
   } catch (error) {
     if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- ensure login form validation returns `{ isValid: false, errors }` when any errors collected
- return `{ isValid: true }` only when no errors exist

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: numerous lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68ac2100debc83319f2a1a66995d5da1