### PR TITLE
fix: move password tooltip state out of render

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -15,8 +15,8 @@ export default function NotFound() {
           </h1>
 
           <p className='text-muted-foreground mb-10 text-xl'>
-            Sorry, we couldn't find the page you're looking for. The page might have been removed or
-            the URL might be incorrect.
+            Sorry, we couldn&apos;t find the page you&apos;re looking for. The page might have been
+            removed or the URL might be incorrect.
           </p>
 
           <div className='flex flex-col items-center gap-4 sm:flex-row sm:justify-center'>

--- a/src/features/auth/components/forms/RegistrationForm.tsx
+++ b/src/features/auth/components/forms/RegistrationForm.tsx
@@ -25,6 +25,13 @@ export const RegistrationForm: React.FC = () => {
     },
   });
 
+  // Manage visibility of the password strength tooltip.
+  // The previous implementation created this state inside the
+  // `render` callback of `FormField`, which violates the React
+  // Hooks rules by calling `useState` conditionally. Defining it
+  // here ensures the hook executes consistently on every render.
+  const [showTooltip, setShowTooltip] = React.useState(false);
+
   const onSubmit = (data: RegisterFormData) => {
     console.log(data);
     // Handle form submission
@@ -132,8 +139,6 @@ export const RegistrationForm: React.FC = () => {
               control={form.control}
               name='password'
               render={({ field }) => {
-                const [showTooltip, setShowTooltip] = React.useState(false);
-
                 return (
                   <FormItem className='relative'>
                     <FormControl>


### PR DESCRIPTION
## Summary
- avoid React hook rule violation by moving password strength tooltip state out of render
- escape apostrophes in 404 page copy

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*
- `npm run build` *(fails: Failed to fetch font `Poppins`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1f96bafc83318b7c78c19cad4a71